### PR TITLE
Updated Dockerfile to include elasticsearch -v 7.13.0 gem installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Fluentd with elasticsearch and kibana 
 
 ### Docker-compose.yml
-```
+```yaml
 version: '3'
 services:
   web:
@@ -43,7 +43,7 @@ services:
       - "5601:5601"
 ```
 ### fluent.conf
-```
+``` conf
 <source>
   @type forward
   port 24224
@@ -74,6 +74,7 @@ services:
 ```
 FROM fluent/fluentd:v1.12.0-debian-1.0
 USER root
+RUN ["gem", "install", "elasticsearch", "--no-document", "--version", "7.13.0"]
 RUN ["gem", "install", "fluent-plugin-elasticsearch", "--no-document", "--version", "5.0.3"]
 USER fluent
 ```

--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -1,4 +1,5 @@
 FROM fluent/fluentd:v1.12.0-debian-1.0
 USER root
+RUN ["gem", "install", "elasticsearch", "--no-document", "--version", "7.13.0"]
 RUN ["gem", "install", "fluent-plugin-elasticsearch", "--no-document", "--version", "5.0.3"]
 USER fluent


### PR DESCRIPTION
Hello,

I noticed an issue with the Dockerfile in the current setup due to a missing gem required for Elasticsearch. This was causing the Fluentd service to fail. 

To solve this, I have updated the Dockerfile to include the required Elasticsearch gem and its specific version that is compatible with this setup. 

I have tested these changes on my local machine, and it now works as expected.

I hope you find these changes useful, and I'm happy to make any further adjustments as needed.

Best regards, Juan Giriboni
